### PR TITLE
Added action hook when new user is registered

### DIFF
--- a/public/class-wp-rest-user-public.php
+++ b/public/class-wp-rest-user-public.php
@@ -132,7 +132,7 @@ class Wp_Rest_User_Public {
 				// Ger User Meta Data (Sensitive, Password included. DO NOT pass to front end.)
 				$user = get_user_by('id', $user_id);
 				$user->set_role($role);
-				// $user->set_role('subscriber');
+				do_action( 'wp_rest_user_create_user', $user );
 
 				// Ger User Data (Non-Sensitive, Pass to front end.)
 				$response['code'] = 200;


### PR DESCRIPTION
This action allows another plugin to hook into the logic after a new user has been created and modify $user for additional adjustments. Use cases include setting a custom role, putting the user in a taxonomy (group), sending an email, etc.